### PR TITLE
Identify xamarin transactions & Persistant Device identification for fraud

### DIFF
--- a/samples/Android/Android.Xamarin.SampleApp/WithUIActivity.cs
+++ b/samples/Android/Android.Xamarin.SampleApp/WithUIActivity.cs
@@ -20,9 +20,9 @@ namespace Android.Xamarin.SampleApp
     public class WithUIActivity : Activity
     {
         // Configure your JudoID and payment detail
-        private const string ApiToken   = "4eVWyZQnO5DyaXZy";
-        private const string ApiSecret  = "1d5e8381ed9ef3cc1ecc1daaf8ce550bdc97ea058ac804be4b68c28d02fdb791";
-        private string MY_JUDO_ID       = "100016";
+		private const string ApiToken   = "MzEtkQK1bHi8v8qy";
+		private const string ApiSecret  = "c158b4997dfc7595a149a20852f7af2ea2e70bd2df794b8bdbc019cc5f799aa1";
+		private string MY_JUDO_ID       = "100915867";
         private string currency         = "GBP";
         private string amount           = "4.99";
         private string paymentReference = "payment101010102";
@@ -54,7 +54,7 @@ namespace Android.Xamarin.SampleApp
             SetContentView(Resource.Layout.withui);
 
             // setting up API token/secret 
-            JudoSDKManager.Configuration.SetApiTokenAndSecret(ApiToken, ApiSecret);
+			JudoSDKManager.Configuration.SetApiTokenAndSecret(ApiToken, ApiSecret,JudoPayDotNet.Enums.Environment.Live);
             JudoSDKManager.Configuration.IsAVSEnabled = true;
             JudoSDKManager.Configuration.IsFraudMonitoringSignals = true;
             JudoSDKManager.Configuration.IsMaestroEnabled = true;

--- a/samples/Android/Android.Xamarin.SampleApp/WithUIActivity.cs
+++ b/samples/Android/Android.Xamarin.SampleApp/WithUIActivity.cs
@@ -20,9 +20,9 @@ namespace Android.Xamarin.SampleApp
     public class WithUIActivity : Activity
     {
         // Configure your JudoID and payment detail
-		private const string ApiToken   = "MzEtkQK1bHi8v8qy";
-		private const string ApiSecret  = "c158b4997dfc7595a149a20852f7af2ea2e70bd2df794b8bdbc019cc5f799aa1";
-		private string MY_JUDO_ID       = "100915867";
+		private const string ApiToken   = "[Application ApiToken]";//retrieve from JudoPortal
+		private const string ApiSecret  = "[Application ApiSecret]";//retrieve from JudoPortal
+		private string MY_JUDO_ID       = "[Judo ID]"; //Received when registering an account with Judo
         private string currency         = "GBP";
         private string amount           = "4.99";
         private string paymentReference = "payment101010102";
@@ -54,7 +54,7 @@ namespace Android.Xamarin.SampleApp
             SetContentView(Resource.Layout.withui);
 
             // setting up API token/secret 
-			JudoSDKManager.Configuration.SetApiTokenAndSecret(ApiToken, ApiSecret,JudoPayDotNet.Enums.Environment.Live);
+			JudoSDKManager.Configuration.SetApiTokenAndSecret(ApiToken,ApiSecret);
             JudoSDKManager.Configuration.IsAVSEnabled = true;
             JudoSDKManager.Configuration.IsFraudMonitoringSignals = true;
             JudoSDKManager.Configuration.IsMaestroEnabled = true;

--- a/samples/Android/Android.Xamarin.SampleApp/WithoutUIActivity.cs
+++ b/samples/Android/Android.Xamarin.SampleApp/WithoutUIActivity.cs
@@ -22,9 +22,9 @@ namespace Android.Xamarin.SampleApp
     public class WithoutUIActivity : Activity
     {
         // Configure your JudoID and payment detail
-        private const string ApiToken   = "4eVWyZQnO5DyaXZy";
-        private const string ApiSecret  = "1d5e8381ed9ef3cc1ecc1daaf8ce550bdc97ea058ac804be4b68c28d02fdb791";
-        private string MY_JUDO_ID       = "100016";
+		private const string ApiToken   = "MzEtkQK1bHi8v8qy";
+		private const string ApiSecret  = "c158b4997dfc7595a149a20852f7af2ea2e70bd2df794b8bdbc019cc5f799aa1";
+		private string MY_JUDO_ID       = "100915867";
         private string currency         = "GBP";
         private decimal amount          = 4.99M;
         private string paymentReference = "payment101010102";
@@ -64,7 +64,7 @@ namespace Android.Xamarin.SampleApp
             SetContentView(Resource.Layout.withoutui);
 
             // setting up API token/secret 
-            JudoSDKManager.Configuration.SetApiTokenAndSecret(ApiToken, ApiSecret);
+            JudoSDKManager.Configuration.SetApiTokenAndSecret(ApiToken, ApiSecret,JudoPayDotNet.Enums.Environment.Live);
             JudoSDKManager.Configuration.IsAVSEnabled = true;
             JudoSDKManager.Configuration.IsFraudMonitoringSignals = true;
             JudoSDKManager.Configuration.IsMaestroEnabled = true;

--- a/samples/Android/Android.Xamarin.SampleApp/WithoutUIActivity.cs
+++ b/samples/Android/Android.Xamarin.SampleApp/WithoutUIActivity.cs
@@ -22,9 +22,9 @@ namespace Android.Xamarin.SampleApp
     public class WithoutUIActivity : Activity
     {
         // Configure your JudoID and payment detail
-		private const string ApiToken   = "MzEtkQK1bHi8v8qy";
-		private const string ApiSecret  = "c158b4997dfc7595a149a20852f7af2ea2e70bd2df794b8bdbc019cc5f799aa1";
-		private string MY_JUDO_ID       = "100915867";
+		private const string ApiToken   = "[Application ApiToken]";//retrieve from JudoPortal
+		private const string ApiSecret  = "[Application ApiSecret]";//retrieve from JudoPortal
+		private string MY_JUDO_ID       = "[Judo ID]"; //Received when registering an account with Judo
         private string currency         = "GBP";
         private decimal amount          = 4.99M;
         private string paymentReference = "payment101010102";

--- a/samples/iOS/JudoPayiOSXamarinSampleApp.sln
+++ b/samples/iOS/JudoPayiOSXamarinSampleApp.sln
@@ -116,6 +116,9 @@ Global
 		{5E165F2E-27FC-4C2E-9ABD-7B54431D4333}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{5E165F2E-27FC-4C2E-9ABD-7B54431D4333}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		version = 2.1.0
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/samples/iOS/JudoPayiOSXamarinSampleApp/JudoPayiOSXamarinSampleApp.csproj
+++ b/samples/iOS/JudoPayiOSXamarinSampleApp/JudoPayiOSXamarinSampleApp.csproj
@@ -24,6 +24,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <ReleaseVersion>2.1.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/iOS/JudoPayiOSXamarinSampleApp/RootView.xib
+++ b/samples/iOS/JudoPayiOSXamarinSampleApp/RootView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>

--- a/src/JudoDotNetXamarin/JudoDotNetXamarin.csproj
+++ b/src/JudoDotNetXamarin/JudoDotNetXamarin.csproj
@@ -15,6 +15,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <ReleaseVersion>2.1.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/JudoDotNetXamarinAndroidSDK/Activies/PaymentActivity.cs
+++ b/src/JudoDotNetXamarinAndroidSDK/Activies/PaymentActivity.cs
@@ -169,7 +169,9 @@ namespace JudoDotNetXamarinSDK.Activies
                 StartDate = startDate,
                 ExpiryDate = expiryDate,
                 CV2 = cv2,
-                ClientDetails = JudoSDKManager.GetClientDetails(this)
+                ClientDetails = JudoSDKManager.GetClientDetails(this),
+				UserAgent = JudoSDKManager.GetSDKVersion()
+					
             };
 
             ShowLoadingSpinner(true);

--- a/src/JudoDotNetXamarinAndroidSDK/Activies/PaymentTokenActivity.cs
+++ b/src/JudoDotNetXamarinAndroidSDK/Activies/PaymentTokenActivity.cs
@@ -106,7 +106,8 @@ namespace JudoDotNetXamarinSDK.Activies
                 YourPaymentMetaData = judoMetaData.Metadata,
                 CardToken = judoCardToken.Token,
                 CV2 = cv2EntryView.GetCV2(),
-                ClientDetails = JudoSDKManager.GetClientDetails(this)
+                ClientDetails = JudoSDKManager.GetClientDetails(this),
+				UserAgent = JudoSDKManager.GetSDKVersion()
             };
 
             ShowLoadingSpinner(true);

--- a/src/JudoDotNetXamarinAndroidSDK/Activies/PreAuthActivity.cs
+++ b/src/JudoDotNetXamarinAndroidSDK/Activies/PreAuthActivity.cs
@@ -69,7 +69,8 @@ namespace JudoDotNetXamarinSDK.Activies
                 StartDate = startDate,
                 ExpiryDate = expiryDate,
                 CV2 = cv2,
-                ClientDetails = JudoSDKManager.GetClientDetails(this)
+                ClientDetails = JudoSDKManager.GetClientDetails(this),
+				UserAgent = JudoSDKManager.GetSDKVersion()
             };
 
             ShowLoadingSpinner(true);

--- a/src/JudoDotNetXamarinAndroidSDK/Activies/PreAuthTokenActivity.cs
+++ b/src/JudoDotNetXamarinAndroidSDK/Activies/PreAuthTokenActivity.cs
@@ -38,7 +38,8 @@ namespace JudoDotNetXamarinSDK.Activies
                 YourPaymentMetaData = judoMetaData.Metadata,
                 CardToken = judoCardToken.Token,
                 CV2 = cv2EntryView.GetCV2(),
-                ClientDetails = JudoSDKManager.GetClientDetails(this)
+                ClientDetails = JudoSDKManager.GetClientDetails(this),
+				UserAgent = JudoSDKManager.GetSDKVersion()
             };
 
             ShowLoadingSpinner(true);

--- a/src/JudoDotNetXamarinAndroidSDK/Clients/NonUIMethods.cs
+++ b/src/JudoDotNetXamarinAndroidSDK/Clients/NonUIMethods.cs
@@ -24,7 +24,8 @@ namespace JudoDotNetXamarinSDK.Clients
                 StartDate = startDate,
                 ExpiryDate = expiryDate,
                 CV2 = cv2,
-                ClientDetails = JudoSDKManager.GetClientDetails(context)
+                ClientDetails = JudoSDKManager.GetClientDetails(context),
+				UserAgent = JudoSDKManager.GetSDKVersion()
             };
 
             return JudoSDKManager.JudoClient.Payments.Create(cardPayment);
@@ -45,7 +46,8 @@ namespace JudoDotNetXamarinSDK.Clients
                 YourPaymentMetaData = metaData,
                 CardToken = cardToken,
                 CV2 = cv2,
-                ClientDetails = JudoSDKManager.GetClientDetails(context)
+                ClientDetails = JudoSDKManager.GetClientDetails(context),
+				UserAgent = JudoSDKManager.GetSDKVersion()
             };
 
             return JudoSDKManager.JudoClient.Payments.Create(payment);
@@ -68,7 +70,8 @@ namespace JudoDotNetXamarinSDK.Clients
                 StartDate = startDate,
                 ExpiryDate = expiryDate,
                 CV2 = cv2,
-                ClientDetails = JudoSDKManager.GetClientDetails(context)
+                ClientDetails = JudoSDKManager.GetClientDetails(context),
+				UserAgent = JudoSDKManager.GetSDKVersion()
             };
 
             return JudoSDKManager.JudoClient.PreAuths.Create(cardPayment);
@@ -89,7 +92,8 @@ namespace JudoDotNetXamarinSDK.Clients
                 YourPaymentMetaData = metaData,
                 CardToken = cardToken,
                 CV2 = cv2,
-                ClientDetails = JudoSDKManager.GetClientDetails(context)
+                ClientDetails = JudoSDKManager.GetClientDetails(context),
+				UserAgent = JudoSDKManager.GetSDKVersion()
             };
 
             return JudoSDKManager.JudoClient.PreAuths.Create(payment);

--- a/src/JudoDotNetXamarinAndroidSDK/JudoDotNetXamarinAndroidSDK.csproj
+++ b/src/JudoDotNetXamarinAndroidSDK/JudoDotNetXamarinAndroidSDK.csproj
@@ -14,8 +14,8 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
-    <TargetFrameworkVersion>v5.1</TargetFrameworkVersion>
-    <ReleaseVersion>2.0</ReleaseVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <ReleaseVersion>2.1.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/JudoDotNetXamarinAndroidSDK/JudoSDKManager.cs
+++ b/src/JudoDotNetXamarinAndroidSDK/JudoSDKManager.cs
@@ -26,6 +26,7 @@ using Consumer = JudoDotNetXamarinSDK.Models.Consumer;
 using Environment = JudoPayDotNet.Enums.Environment;
 using Error = JudoDotNetXamarinSDK.Models.Error;
 using Result = Android.App.Result;
+using System.Diagnostics;
 
 namespace JudoDotNetXamarinSDK
 {
@@ -228,5 +229,14 @@ namespace JudoDotNetXamarinSDK
         {
             return JObject.FromObject(ClientDetailsProvider.GetClientDetails(context));
         }
+
+		internal static string GetSDKVersion ()
+		{
+			System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
+			FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+			string version = fvi.FileVersion;
+
+			return "Xamarin-Android-" + version;
+		}
     }
 }

--- a/src/JudoDotNetXamarinAndroidSDK/Properties/AssemblyInfo.cs
+++ b/src/JudoDotNetXamarinAndroidSDK/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using Android.App;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("JudoDotNetXamarinSDK")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © JudoPay  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
@@ -26,5 +26,5 @@ using Android.App;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.1.0")]
+[assembly: AssemblyFileVersion("2.1.0")]

--- a/src/JudoDotNetXamariniOSSDK/JudoDotNetXamariniOSSDK.csproj
+++ b/src/JudoDotNetXamariniOSSDK/JudoDotNetXamariniOSSDK.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>JudoDotNetXamariniOSSDK</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>JudoDotNetXamariniOSSDK</AssemblyName>
-    <ReleaseVersion>2.0</ReleaseVersion>
+    <ReleaseVersion>2.1.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/JudoDotNetXamariniOSSDK/JudoSDKManager.cs
+++ b/src/JudoDotNetXamariniOSSDK/JudoSDKManager.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using Environment = JudoPayDotNet.Enums.Environment;
 using System.Drawing;
 using PassKit;
+using System.Diagnostics;
 
 
 #if __UNIFIED__
@@ -121,6 +122,15 @@ namespace JudoDotNetXamariniOSSDK
 
             return null;
         }
+
+		public static string GetSDKVersion ()
+		{
+			System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
+			FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+			string version = fvi.FileVersion;
+
+			return "Xamarin-iOS-" + version;
+		}
 
 		internal static void SetUserAgent ()
 		{

--- a/src/JudoDotNetXamariniOSSDK/Properties/AssemblyInfo.cs
+++ b/src/JudoDotNetXamariniOSSDK/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("")]
 [assembly: AssemblyProduct ("")]
-[assembly: AssemblyCopyright ("Luke.Fieldsend")]
+[assembly: AssemblyCopyright ("Judo Payments")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 

--- a/src/JudoDotNetXamariniOSSDK/Properties/AssemblyInfo.cs
+++ b/src/JudoDotNetXamariniOSSDK/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("")]
 [assembly: AssemblyProduct ("")]
-[assembly: AssemblyCopyright ("igor.candido")]
+[assembly: AssemblyCopyright ("Luke.Fieldsend")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("2.1.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/src/JudoDotNetXamariniOSSDK/Services/ApplePayService.cs
+++ b/src/JudoDotNetXamariniOSSDK/Services/ApplePayService.cs
@@ -64,6 +64,7 @@ namespace JudoDotNetXamariniOSSDK
 				CardPaymentModel paymentmodel = new CardPaymentModel {
 					JudoId = JudoConfiguration.Instance.JudoId,
 					ClientDetails = JudoSDKManager.GetClientDetails (),
+					UserAgent = JudoSDKManager.GetSDKVersion()
 				};
 
 
@@ -75,6 +76,7 @@ namespace JudoDotNetXamariniOSSDK
 					YourConsumerReference = customerRef,
 					Amount = amount.ToDecimal (),
 					ClientDetails = JudoSDKManager.GetClientDetails (),
+					UserAgent = JudoSDKManager.GetSDKVersion(),
 					PkPayment = new PKPaymentInnerModel () {
 						Token = new PKPaymentTokenModel () {
 							PaymentData = jo,

--- a/src/JudoDotNetXamariniOSSDK/Services/PaymentService.cs
+++ b/src/JudoDotNetXamariniOSSDK/Services/PaymentService.cs
@@ -33,7 +33,8 @@ namespace JudoDotNetXamariniOSSDK
                     IssueNumber = paymentViewModel.Card.IssueNumber,
                     YourPaymentMetaData = paymentViewModel.YourPaymentMetaData,
                     ClientDetails = JudoSDKManager.GetClientDetails(),
-                    Currency = paymentViewModel.Currency
+                    Currency = paymentViewModel.Currency,
+					UserAgent = JudoSDKManager.GetSDKVersion()
                 };
 
                 Task<IResult<ITransactionResult>> task =  _judoAPI.Payments.Create(payment);
@@ -65,6 +66,7 @@ namespace JudoDotNetXamariniOSSDK
                     IssueNumber = authorisation.Card.IssueNumber,
                     YourPaymentMetaData = authorisation.YourPaymentMetaData,
                     ClientDetails = JudoSDKManager.GetClientDetails(),
+					UserAgent = JudoSDKManager.GetSDKVersion(),
                     Currency = authorisation.Currency
                 };
 
@@ -92,7 +94,8 @@ namespace JudoDotNetXamariniOSSDK
 				    CV2 = tokenPayment.CV2,
                     ConsumerToken = tokenPayment.ConsumerToken,
                     YourPaymentMetaData = tokenPayment.YourPaymentMetaData,
-                    ClientDetails = JudoSDKManager.GetClientDetails()
+                    ClientDetails = JudoSDKManager.GetClientDetails(),
+					UserAgent = JudoSDKManager.GetSDKVersion()
 			    };
 				Task<IResult<ITransactionResult>> task =  _judoAPI.Payments.Create(payment);
 				return await task;
@@ -115,7 +118,8 @@ namespace JudoDotNetXamariniOSSDK
 				CV2 = tokenPayment.CV2,
                 ConsumerToken = tokenPayment.ConsumerToken,
                 YourPaymentMetaData = tokenPayment.YourPaymentMetaData,
-                ClientDetails = JudoSDKManager.GetClientDetails()
+                ClientDetails = JudoSDKManager.GetClientDetails(),
+				UserAgent = JudoSDKManager.GetSDKVersion()
 			};
 			try
 			{

--- a/src/JudoXamarin.sln
+++ b/src/JudoXamarin.sln
@@ -61,7 +61,7 @@ Global
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = None
 		$1.ResourceNamePolicy = FileFormatDefault
-		version = 2.0
+		version = 2.1.0
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- integrated in a private judoShield component to persist the device serial number
- xamarin transactions now include the sdk name and version in the USERAGENT REST header