### PR TITLE
Life cycle bug hotfix

### DIFF
--- a/samples/Android/Android.Xamarin.SampleApp/WithUIActivity.cs
+++ b/samples/Android/Android.Xamarin.SampleApp/WithUIActivity.cs
@@ -22,7 +22,7 @@ namespace Android.Xamarin.SampleApp
         private const string cardNumber = "4976000000003436";
         private const string addressPostCode = "TR14 8PA";
         private const string startDate = "";
-        private  const string expiryDate = "12/15";
+        private  const string expiryDate = "12/20";
         private const string cv2 = "452";
 
         private volatile string cardToken;

--- a/src/JudoDotNetXamarinAndroidSDK/Clients/UIMethods.cs
+++ b/src/JudoDotNetXamarinAndroidSDK/Clients/UIMethods.cs
@@ -29,11 +29,13 @@ namespace JudoDotNetXamarinAndroidSDK
         protected override void OnCreate (Android.OS.Bundle savedInstanceState)
         {
             base.OnCreate (savedInstanceState);
-            Intent i;
-            var requestCode = Intent.GetStringExtra (Judo.REQUEST_CODE);
-            PopulateIntent (out i);
+            if (savedInstanceState == null) {
+                Intent i;
+                var requestCode = Intent.GetStringExtra (Judo.REQUEST_CODE);
+                PopulateIntent (out i);
 
-            this.StartActivityForResult (i, Int32.Parse (requestCode));
+                this.StartActivityForResult (i, Int32.Parse (requestCode));
+            }
         }
 
         public void Payment (PaymentViewModel payment, JudoSuccessCallback success, JudoFailureCallback failure, Activity context)


### PR DESCRIPTION
When a developer option is set on device to aggressively clear views the activity manager view tries to refresh itself. This check prevents this 
